### PR TITLE
add workflow to test specific `analytics-cli` version

### DIFF
--- a/.github/actions/analytics-uploader-wrapper/action.yaml
+++ b/.github/actions/analytics-uploader-wrapper/action.yaml
@@ -1,0 +1,42 @@
+name: Trunk Analytics Uploader Wrapper
+description: Wrapper that supplies defaults to the `analytics-uploader` action
+
+inputs:
+  token:
+    description: Organization token. Defaults to TRUNK_API_TOKEN env var.
+    required: false
+  junit-paths:
+    description: Comma-separated list of glob paths to junit files.
+    required: true
+  run:
+    description: The command to run before uploading test results.
+    required: false
+  cli-version:
+    description: The version of the uploader to use.
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Upload test results with CLI version ${{ inputs.cli-version }}
+      if: "${{ inputs.cli-version != '' }}"
+      uses: trunk-io/analytics-uploader@main
+      with:
+        org-slug: trunk-staging-org
+        token: ${{ inputs.token }}
+        cli-version: ${{ inputs.cli-version }}
+        junit-paths: ${{ inputs.junit-paths }}
+        run: ${{ inputs.run }}
+      env:
+        TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
+
+    - name: Upload test results with default CLI version
+      if: "${{ inputs.cli-version == '' }}"
+      uses: trunk-io/analytics-uploader@main
+      with:
+        org-slug: trunk-staging-org
+        token: ${{ inputs.token }}
+        junit-paths: ${{ inputs.junit-paths }}
+        run: ${{ inputs.run }}
+      env:
+        TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io

--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -22,13 +22,7 @@ jobs:
         run: bazel test //bazel/gtest:hello_test
 
       - name: upload tests
-        uses: trunk-io/analytics-uploader@main
+        uses: ./.github/actions/analytics-uploader-wrapper
         with:
-          # Path to your test results.
-          junit-paths: bazel-testlogs/**/test.xml
-          # Provide your Trunk organization slug.
-          org-slug: trunk-staging-org
-          # Provide your Trunk API token as a GitHub secret.
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
-        env:
-          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
+          junit-paths: bazel-testlogs/**/test.xml

--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -22,6 +22,7 @@ jobs:
         run: bazel test //bazel/gtest:hello_test
 
       - name: upload tests
+        if: ${{ always() }}
         uses: ./.github/actions/analytics-uploader-wrapper
         with:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}

--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -7,6 +7,15 @@ on:
     - cron: 0 */6 * * *
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      # trunk-ignore(checkov/CKV_GHA_7)
+      cli-version:
+        type: string
+        required: false
+        description:
+          The version of `analytics-cli` to use. Defaults to the latest specified in
+          `analytis-uploader`.
 
 jobs:
   test:
@@ -26,4 +35,5 @@ jobs:
         uses: ./.github/actions/analytics-uploader-wrapper
         with:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          cli-version: ${{ inputs.cli-version }}
           junit-paths: bazel-testlogs/**/test.xml

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -5,6 +5,15 @@ on:
     - cron: 0 */6 * * *
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      # trunk-ignore(checkov/CKV_GHA_7)
+      cli-version:
+        type: string
+        required: false
+        description:
+          The version of `analytics-cli` to use. Defaults to the latest specified in
+          `analytis-uploader`.
 
 jobs:
   test:
@@ -30,6 +39,7 @@ jobs:
         uses: ./.github/actions/analytics-uploader-wrapper
         with:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          cli-version: ${{ inputs.cli-version }}
           junit-paths: "**/*_test.xml"
 
       - name: Run tests with gotestsum
@@ -42,4 +52,5 @@ jobs:
         uses: ./.github/actions/analytics-uploader-wrapper
         with:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          cli-version: ${{ inputs.cli-version }}
           junit-paths: "**/*_test.xml"

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go Action
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.5'
+          go-version: "1.22.5"
       - name: Install dependencies
         run: |
           go install github.com/jstemmer/go-junit-report/v2@latest
@@ -26,32 +26,17 @@ jobs:
         working-directory: go/src
 
       - name: Upload test results
-        uses: trunk-io/analytics-uploader@main
+        uses: ./.github/actions/analytics-uploader-wrapper
         with:
-          # Path to your test results.
-          junit-paths: "**/*_test.xml"
-          # Provide your Trunk organization slug.
-          org-slug: trunk-staging-org
-          # Provide your Trunk API token as a GitHub secret.
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
-        env:
-          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
+          junit-paths: "**/*_test.xml"
 
       - name: Run tests with gotestsum
         run: gotestsum --junitfile gotestsum_test.xml
         working-directory: go/src
 
       - name: Upload test results
-        uses: trunk-io/analytics-uploader@main
+        uses: ./.github/actions/analytics-uploader-wrapper
         with:
-          # Path to your test results.
-          junit-paths: "**/*_test.xml"
-          # Provide your Trunk organization slug.
-          org-slug: trunk-staging-org
-          # Provide your Trunk API token as a GitHub secret.
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
-        env:
-          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
-
-
-
+          junit-paths: "**/*_test.xml"

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -26,16 +26,19 @@ jobs:
         working-directory: go/src
 
       - name: Upload test results
+        if: ${{ always() }}
         uses: ./.github/actions/analytics-uploader-wrapper
         with:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
           junit-paths: "**/*_test.xml"
 
       - name: Run tests with gotestsum
+        if: ${{ always() }}
         run: gotestsum --junitfile gotestsum_test.xml
         working-directory: go/src
 
       - name: Upload test results
+        if: ${{ always() }}
         uses: ./.github/actions/analytics-uploader-wrapper
         with:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}

--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -5,6 +5,15 @@ on:
     - cron: 0 */6 * * *
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      # trunk-ignore(checkov/CKV_GHA_7)
+      cli-version:
+        type: string
+        required: false
+        description:
+          The version of `analytics-cli` to use. Defaults to the latest specified in
+          `analytis-uploader`.
 
 jobs:
   test:
@@ -25,6 +34,7 @@ jobs:
         uses: ./.github/actions/analytics-uploader-wrapper
         with:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          cli-version: ${{ inputs.cli-version }}
           junit-paths: "**/gradle/**/test-results/**/*.xml"
           run: gradle test --project-dir java/gradle
 
@@ -33,6 +43,7 @@ jobs:
         uses: ./.github/actions/analytics-uploader-wrapper
         with:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          cli-version: ${{ inputs.cli-version }}
           junit-paths: "**/surefire-reports/*.xml"
           run: mvn test --file java/maven/pom.xml --quiet
 
@@ -41,5 +52,6 @@ jobs:
         uses: ./.github/actions/analytics-uploader-wrapper
         with:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          cli-version: ${{ inputs.cli-version }}
           junit-paths: "**/playwright/**/surefire-reports/*.xml"
           run: mvn test --file java/playwright/pom.xml --quiet

--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -22,39 +22,24 @@ jobs:
 
       - name: Run tests with Gradle
         if: ${{ always() }}
-        uses: trunk-io/analytics-uploader@main
+        uses: ./.github/actions/analytics-uploader-wrapper
         with:
-          junit-paths: "**/gradle/**/test-results/**/*.xml"
-          org-slug: trunk-staging-org
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          junit-paths: "**/gradle/**/test-results/**/*.xml"
           run: gradle test --project-dir java/gradle
-        env:
-          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
 
       - name: Run tests with Maven
         if: ${{ always() }}
-        uses: trunk-io/analytics-uploader@main
+        uses: ./.github/actions/analytics-uploader-wrapper
         with:
-          # Path to your test results.
-          junit-paths: "**/surefire-reports/*.xml"
-          # Provide your Trunk organization slug.
-          org-slug: trunk-staging-org
-          # Provide your Trunk API token as a GitHub secret.
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          junit-paths: "**/surefire-reports/*.xml"
           run: mvn test --file java/maven/pom.xml --quiet
-        env:
-          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
 
       - name: Run playwright tests with Maven
         if: ${{ always() }}
-        uses: trunk-io/analytics-uploader@main
+        uses: ./.github/actions/analytics-uploader-wrapper
         with:
-          # Path to your test results.
-          junit-paths: "**/playwright/**/surefire-reports/*.xml"
-          # Provide your Trunk organization slug.
-          org-slug: trunk-staging-org
-          # Provide your Trunk API token as a GitHub secret.
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          junit-paths: "**/playwright/**/surefire-reports/*.xml"
           run: mvn test --file java/playwright/pom.xml --quiet
-        env:
-          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io

--- a/.github/workflows/javascript-tests.yaml
+++ b/.github/workflows/javascript-tests.yaml
@@ -27,56 +27,32 @@ jobs:
           pnpm install
 
       - name: Run Mocha Tests
-        uses: trunk-io/analytics-uploader@main
+        uses: ./.github/actions/analytics-uploader-wrapper
         with:
-          # Path to your test results.
-          junit-paths: "**/mocha_test.xml"
-          # Provide your Trunk organization slug.
-          org-slug: trunk-staging-org
-          # Provide your Trunk API token as a GitHub secret.
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          junit-paths: "**/mocha_test.xml"
           run: npm run mocha-test
-        env:
-          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
 
       - name: Run Jest Tests
         if: ${{ always() }}
-        uses: trunk-io/analytics-uploader@main
+        uses: ./.github/actions/analytics-uploader-wrapper
         with:
-          # Path to your test results.
-          junit-paths: "**/*_test.xml,**/junitresults-*.xml"
-          # Provide your Trunk organization slug.
-          org-slug: trunk-staging-org
-          # Provide your Trunk API token as a GitHub secret.
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          junit-paths: "**/*_test.xml,**/junitresults-*.xml"
           run: npm run jest-test
-        env:
-          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
 
       - name: Run Jasmine Tests
         if: ${{ always() }}
-        uses: trunk-io/analytics-uploader@main
+        uses: ./.github/actions/analytics-uploader-wrapper
         with:
-          # Path to your test results.
-          junit-paths: "**/*_test.xml,**/junitresults-*.xml"
-          # Provide your Trunk organization slug.
-          org-slug: trunk-staging-org
-          # Provide your Trunk API token as a GitHub secret.
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          junit-paths: "**/*_test.xml,**/junitresults-*.xml"
           run: npm run jasmine-test
-        env:
-          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
+
       - name: Run Playwright Tests
         if: ${{ always() }}
-        uses: trunk-io/analytics-uploader@main
+        uses: ./.github/actions/analytics-uploader-wrapper
         with:
-          # Path to your test results.
-          junit-paths: "**/*_test.xml,**/junitresults-*.xml"
-          # Provide your Trunk organization slug.
-          org-slug: trunk-staging-org
-          # Provide your Trunk API token as a GitHub secret.
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          junit-paths: "**/*_test.xml,**/junitresults-*.xml"
           run: npm run playwright-test
-        env:
-          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
-

--- a/.github/workflows/javascript-tests.yaml
+++ b/.github/workflows/javascript-tests.yaml
@@ -5,6 +5,15 @@ on:
     - cron: 0 */6 * * *
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      # trunk-ignore(checkov/CKV_GHA_7)
+      cli-version:
+        type: string
+        required: false
+        description:
+          The version of `analytics-cli` to use. Defaults to the latest specified in
+          `analytis-uploader`.
 
 jobs:
   test:
@@ -30,6 +39,7 @@ jobs:
         uses: ./.github/actions/analytics-uploader-wrapper
         with:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          cli-version: ${{ inputs.cli-version }}
           junit-paths: "**/mocha_test.xml"
           run: npm run mocha-test
 
@@ -38,6 +48,7 @@ jobs:
         uses: ./.github/actions/analytics-uploader-wrapper
         with:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          cli-version: ${{ inputs.cli-version }}
           junit-paths: "**/*_test.xml,**/junitresults-*.xml"
           run: npm run jest-test
 
@@ -46,6 +57,7 @@ jobs:
         uses: ./.github/actions/analytics-uploader-wrapper
         with:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          cli-version: ${{ inputs.cli-version }}
           junit-paths: "**/*_test.xml,**/junitresults-*.xml"
           run: npm run jasmine-test
 
@@ -54,5 +66,6 @@ jobs:
         uses: ./.github/actions/analytics-uploader-wrapper
         with:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          cli-version: ${{ inputs.cli-version }}
           junit-paths: "**/*_test.xml,**/junitresults-*.xml"
           run: npm run playwright-test

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -5,6 +5,15 @@ on:
     - cron: 0 */6 * * *
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      # trunk-ignore(checkov/CKV_GHA_7)
+      cli-version:
+        type: string
+        required: false
+        description:
+          The version of `analytics-cli` to use. Defaults to the latest specified in
+          `analytis-uploader`.
 
 jobs:
   test:
@@ -29,6 +38,7 @@ jobs:
         uses: ./.github/actions/analytics-uploader-wrapper
         with:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          cli-version: ${{ inputs.cli-version }}
           junit-paths: "**/*_test.xml"
           run:
             phpunit -c php/phpunit/phpunit.xml --bootstrap php/phpunit/src/autoload.php --log-junit

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -21,21 +21,15 @@ jobs:
       - name: Setup PHP Action
         uses: shivammathur/setup-php@2.31.1
         with:
-          php-version: '8.3.10'
+          php-version: "8.3.10"
           tools: php-cs-fixer, phpunit
           ini-values: error_reporting=-1, display_errors=On
 
       - name: Run phpunit tests
-        uses: trunk-io/analytics-uploader@main
+        uses: ./.github/actions/analytics-uploader-wrapper
         with:
-          # Path to your test results.
-          junit-paths: "**/*_test.xml"
-          # Provide your Trunk organization slug.
-          org-slug: trunk-staging-org
-          # Provide your Trunk API token as a GitHub secret.
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          junit-paths: "**/*_test.xml"
           run:
-            phpunit -c php/phpunit/phpunit.xml --bootstrap php/phpunit/src/autoload.php --log-junit tests/phpunit_test.xml
-        env:
-          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
-
+            phpunit -c php/phpunit/phpunit.xml --bootstrap php/phpunit/src/autoload.php --log-junit
+            tests/phpunit_test.xml

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -23,32 +23,20 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run pytest tests
-        uses: trunk-io/analytics-uploader@main
+        uses: ./.github/actions/analytics-uploader-wrapper
         with:
-          # Path to your test results.
-          junit-paths: "**/*_test.xml"
-          # Provide your Trunk organization slug.
-          org-slug: trunk-staging-org
-          # Provide your Trunk API token as a GitHub secret.
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          junit-paths: "**/*_test.xml"
           run:
             pytest python/pytest/** --junitxml=python/results/pytest/pytest_test.xml -o
             junit_family=xunit1
-        env:
-          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
 
       - name: Run robotframework tests
-        uses: trunk-io/analytics-uploader@main
+        uses: ./.github/actions/analytics-uploader-wrapper
         if: ${{ always() }}
         with:
-          # Path to your test results.
-          junit-paths: "**/*_test.xml"
-          # Provide your Trunk organization slug.
-          org-slug: trunk-staging-org
-          # Provide your Trunk API token as a GitHub secret.
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          junit-paths: "**/*_test.xml"
           run:
             pabot --testlevelsplit --outputdir=python/results/robotframework --output=robot_test.xml
             python/robotframework/**
-        env:
-          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -5,6 +5,15 @@ on:
     - cron: 0 */6 * * *
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      # trunk-ignore(checkov/CKV_GHA_7)
+      cli-version:
+        type: string
+        required: false
+        description:
+          The version of `analytics-cli` to use. Defaults to the latest specified in
+          `analytis-uploader`.
 
 jobs:
   test:
@@ -26,6 +35,7 @@ jobs:
         uses: ./.github/actions/analytics-uploader-wrapper
         with:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          cli-version: ${{ inputs.cli-version }}
           junit-paths: "**/*_test.xml"
           run:
             pytest python/pytest/** --junitxml=python/results/pytest/pytest_test.xml -o
@@ -36,6 +46,7 @@ jobs:
         if: ${{ always() }}
         with:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          cli-version: ${{ inputs.cli-version }}
           junit-paths: "**/*_test.xml"
           run:
             pabot --testlevelsplit --outputdir=python/results/robotframework --output=robot_test.xml

--- a/.github/workflows/retry-tests.yaml
+++ b/.github/workflows/retry-tests.yaml
@@ -5,6 +5,15 @@ on:
     - cron: 0 */6 * * *
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      # trunk-ignore(checkov/CKV_GHA_7)
+      cli-version:
+        type: string
+        required: false
+        description:
+          The version of `analytics-cli` to use. Defaults to the latest specified in
+          `analytis-uploader`.
 
 jobs:
   test:
@@ -30,6 +39,7 @@ jobs:
         uses: ./.github/actions/analytics-uploader-wrapper
         with:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          cli-version: ${{ inputs.cli-version }}
           junit-paths: "**/python/results/*-behave.xml"
           run: behave --junit-directory=python/results --junit python/behave
 

--- a/.github/workflows/retry-tests.yaml
+++ b/.github/workflows/retry-tests.yaml
@@ -27,17 +27,11 @@ jobs:
 
       - name: test
         id: test
-        uses: trunk-io/analytics-uploader@main
+        uses: ./.github/actions/analytics-uploader-wrapper
         with:
-          # Path to your test results.
-          junit-paths: "**/python/results/*-behave.xml"
-          # Provide your Trunk organization slug.
-          org-slug: trunk-staging-org
-          # Provide your Trunk API token as a GitHub secret.
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          junit-paths: "**/python/results/*-behave.xml"
           run: behave --junit-directory=python/results --junit python/behave
-        env:
-          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
 
       - name: trigger job re-run
         if:

--- a/.github/workflows/ruby-tests.yaml
+++ b/.github/workflows/ruby-tests.yaml
@@ -20,28 +20,16 @@ jobs:
           bundler-cache: true
 
       - name: Run rspec tests
-        uses: trunk-io/analytics-uploader@main
+        uses: ./.github/actions/analytics-uploader-wrapper
         with:
-          # Path to your test results.
-          junit-paths: "**/rspec_test.xml"
-          # Provide your Trunk organization slug.
-          org-slug: trunk-staging-org
-          # Provide your Trunk API token as a GitHub secret.
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          junit-paths: "**/rspec_test.xml"
           run: bundle exec rspec ruby/rspec --format RspecJunitFormatter --out rspec_test.xml
-        env:
-          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
 
       - name: Run minitest tests
         if: ${{ always() }}
-        uses: trunk-io/analytics-uploader@main
+        uses: ./.github/actions/analytics-uploader-wrapper
         with:
-          # Path to your test results.
-          junit-paths: "**/ruby/minitest/results/*.xml"
-          # Provide your Trunk organization slug.
-          org-slug: trunk-staging-org
-          # Provide your Trunk API token as a GitHub secret.
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          junit-paths: "**/ruby/minitest/results/*.xml"
           run: bundle exec ruby ruby/minitest/mixer.rb
-        env:
-          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io

--- a/.github/workflows/ruby-tests.yaml
+++ b/.github/workflows/ruby-tests.yaml
@@ -5,6 +5,15 @@ on:
     - cron: 0 */6 * * *
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      # trunk-ignore(checkov/CKV_GHA_7)
+      cli-version:
+        type: string
+        required: false
+        description:
+          The version of `analytics-cli` to use. Defaults to the latest specified in
+          `analytis-uploader`.
 
 jobs:
   test:
@@ -23,6 +32,7 @@ jobs:
         uses: ./.github/actions/analytics-uploader-wrapper
         with:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          cli-version: ${{ inputs.cli-version }}
           junit-paths: "**/rspec_test.xml"
           run: bundle exec rspec ruby/rspec --format RspecJunitFormatter --out rspec_test.xml
 
@@ -31,5 +41,6 @@ jobs:
         uses: ./.github/actions/analytics-uploader-wrapper
         with:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          cli-version: ${{ inputs.cli-version }}
           junit-paths: "**/ruby/minitest/results/*.xml"
           run: bundle exec ruby ruby/minitest/mixer.rb

--- a/.github/workflows/rust-tests.yaml
+++ b/.github/workflows/rust-tests.yaml
@@ -5,6 +5,15 @@ on:
     - cron: 0 */6 * * *
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      # trunk-ignore(checkov/CKV_GHA_7)
+      cli-version:
+        type: string
+        required: false
+        description:
+          The version of `analytics-cli` to use. Defaults to the latest specified in
+          `analytis-uploader`.
 
 jobs:
   test:
@@ -26,5 +35,6 @@ jobs:
         uses: ./.github/actions/analytics-uploader-wrapper
         with:
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          cli-version: ${{ inputs.cli-version }}
           junit-paths: rust/**/nextest/ci/*junit.xml
           run: cargo nextest run --profile=ci --manifest-path=./rust/Cargo.toml

--- a/.github/workflows/rust-tests.yaml
+++ b/.github/workflows/rust-tests.yaml
@@ -23,14 +23,8 @@ jobs:
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
       - name: Run tests
-        uses: trunk-io/analytics-uploader@main
+        uses: ./.github/actions/analytics-uploader-wrapper
         with:
-          # Path to your test results.
-          junit-paths: rust/**/nextest/ci/*junit.xml
-          # Provide your Trunk organization slug.
-          org-slug: trunk-staging-org
-          # Provide your Trunk API token as a GitHub secret.
           token: ${{ secrets.TRUNK_STAGING_ORG_API_TOKEN }}
+          junit-paths: rust/**/nextest/ci/*junit.xml
           run: cargo nextest run --profile=ci --manifest-path=./rust/Cargo.toml
-        env:
-          TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io

--- a/.github/workflows/test-analytics-cli-version.yaml
+++ b/.github/workflows/test-analytics-cli-version.yaml
@@ -1,0 +1,38 @@
+# trunk-ignore-all(checkov/CKV2_GHA_1)
+name: Test Analytics CLI Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      # trunk-ignore(checkov/CKV_GHA_7)
+      cli-version:
+        type: string
+        required: false
+        description:
+          The version of `analytics-cli` to use. Defaults to the latest specified in
+          `analytis-uploader`.
+      ref:
+        type: string
+        required: false
+        default: main
+        description: The branch or tag name which contains the version of the workflow files to run.
+
+jobs:
+  rerun:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run all test workflows with CLI version ${{ inputs.cli-version || 'latest' }}
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          GH_DEBUG: api
+        run: |
+          gh workflow run bazel.yaml --ref ${{ inputs.ref }} -f cli-version=${{ inputs.cli-version }}
+          gh workflow run go.yaml --ref ${{ inputs.ref }} -f cli-version=${{ inputs.cli-version }}
+          gh workflow run java-tests.yaml --ref ${{ inputs.ref }} -f cli-version=${{ inputs.cli-version }}
+          gh workflow run javascript-tests.yaml --ref ${{ inputs.ref }} -f cli-version=${{ inputs.cli-version }}
+          gh workflow run php.yaml --ref ${{ inputs.ref }} -f cli-version=${{ inputs.cli-version }}
+          gh workflow run python-tests.yaml --ref ${{ inputs.ref }} -f cli-version=${{ inputs.cli-version }}
+          gh workflow run retry-tests.yaml --ref ${{ inputs.ref }} -f cli-version=${{ inputs.cli-version }}
+          gh workflow run ruby-tests.yaml --ref ${{ inputs.ref }} -f cli-version=${{ inputs.cli-version }}
+          gh workflow run rust-tests.yaml --ref ${{ inputs.ref }} -f cli-version=${{ inputs.cli-version }}


### PR DESCRIPTION
Add an easy way to test any version of the `analytics-cli`—perfect for checking if our pre-releases are valid.

Use `gh workflow run` to kick off multiple workflows using the same CLI version.
https://cli.github.com/manual/gh_workflow_run