### PR TITLE
globally enable quarantining for now

### DIFF
--- a/.github/actions/analytics-uploader-wrapper/action.yaml
+++ b/.github/actions/analytics-uploader-wrapper/action.yaml
@@ -27,6 +27,7 @@ runs:
         cli-version: ${{ inputs.cli-version }}
         junit-paths: ${{ inputs.junit-paths }}
         run: ${{ inputs.run }}
+        quarantine: true
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io
 
@@ -38,5 +39,6 @@ runs:
         token: ${{ inputs.token }}
         junit-paths: ${{ inputs.junit-paths }}
         run: ${{ inputs.run }}
+        quarantine: true
       env:
         TRUNK_PUBLIC_API_ADDRESS: https://api.trunk-staging.io


### PR DESCRIPTION
Eventually, we will make this an input to be able to enable quarantining wherever this is used, but for testing this should enable it for all tests