### PR TITLE
(Feat): Use bep parsing and uploading

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,2 @@
+test --build_event_json_file=build_events.json
+test --nobuild_event_json_file_path_conversion

--- a/.github/actions/analytics-uploader-wrapper/action.yaml
+++ b/.github/actions/analytics-uploader-wrapper/action.yaml
@@ -23,6 +23,9 @@ inputs:
   junit-paths:
     description: Comma-separated list of glob paths to junit files.
     required: true
+  bazel-bep-path:
+    description: Path to the Bazel BEP file.
+    required: false
   run:
     description: The command to run before uploading test results.
     required: false
@@ -42,6 +45,7 @@ runs:
         token: ${{ inputs.token-prod }}
         cli-version: ${{ inputs.cli-version }}
         junit-paths: ${{ inputs.junit-paths }}
+        bazel-bep-path: ${{ inputs.bazel-bep-path }}
         run: ${{ inputs.run }}
         quarantine: false
 
@@ -54,6 +58,7 @@ runs:
         token: ${{ inputs.token-staging }}
         cli-version: ${{ inputs.cli-version }}
         junit-paths: ${{ inputs.junit-paths }}
+        bazel-bep-path: ${{ inputs.bazel-bep-path }}
         run: ${{ inputs.run }}
         quarantine: true
       env:
@@ -68,6 +73,7 @@ runs:
         token: ${{ inputs.token-dev }}
         cli-version: ${{ inputs.cli-version }}
         junit-paths: ${{ inputs.junit-paths }}
+        bazel-bep-path: ${{ inputs.bazel-bep-path }}
         run: ${{ inputs.run }}
         quarantine: true
       env:
@@ -82,6 +88,7 @@ runs:
         token: ${{ inputs.token-dev2 }}
         cli-version: ${{ inputs.cli-version }}
         junit-paths: ${{ inputs.junit-paths }}
+        bazel-bep-path: ${{ inputs.bazel-bep-path }}
         run: ${{ inputs.run }}
         quarantine: true
       env:
@@ -96,6 +103,7 @@ runs:
         token: ${{ inputs.token-dev3 }}
         cli-version: ${{ inputs.cli-version }}
         junit-paths: ${{ inputs.junit-paths }}
+        bazel-bep-path: ${{ inputs.bazel-bep-path }}
         run: ${{ inputs.run }}
         quarantine: true
       env:
@@ -110,6 +118,7 @@ runs:
         token: ${{ inputs.token-dev4 }}
         cli-version: ${{ inputs.cli-version }}
         junit-paths: ${{ inputs.junit-paths }}
+        bazel-bep-path: ${{ inputs.bazel-bep-path }}
         run: ${{ inputs.run }}
         quarantine: true
       env:
@@ -123,6 +132,7 @@ runs:
         org-slug: trunk
         token: ${{ inputs.token-prod }}
         junit-paths: ${{ inputs.junit-paths }}
+        bazel-bep-path: ${{ inputs.bazel-bep-path }}
         run: ${{ inputs.run }}
         quarantine: false
 
@@ -134,6 +144,7 @@ runs:
         org-slug: trunk-staging-org
         token: ${{ inputs.token-staging }}
         junit-paths: ${{ inputs.junit-paths }}
+        bazel-bep-path: ${{ inputs.bazel-bep-path }}
         run: ${{ inputs.run }}
         quarantine: true
       env:
@@ -147,6 +158,7 @@ runs:
         org-slug: trunk-io
         token: ${{ inputs.token-dev }}
         junit-paths: ${{ inputs.junit-paths }}
+        bazel-bep-path: ${{ inputs.bazel-bep-path }}
         run: ${{ inputs.run }}
         quarantine: true
       env:
@@ -160,6 +172,7 @@ runs:
         org-slug: trunk-io
         token: ${{ inputs.token-dev2 }}
         junit-paths: ${{ inputs.junit-paths }}
+        bazel-bep-path: ${{ inputs.bazel-bep-path }}
         run: ${{ inputs.run }}
         quarantine: true
       env:
@@ -173,6 +186,7 @@ runs:
         org-slug: trunk-io
         token: ${{ inputs.token-dev3 }}
         junit-paths: ${{ inputs.junit-paths }}
+        bazel-bep-path: ${{ inputs.bazel-bep-path }}
         run: ${{ inputs.run }}
         quarantine: true
       env:
@@ -186,6 +200,7 @@ runs:
         org-slug: trunk-io
         token: ${{ inputs.token-dev4 }}
         junit-paths: ${{ inputs.junit-paths }}
+        bazel-bep-path: ${{ inputs.bazel-bep-path }}
         run: ${{ inputs.run }}
         quarantine: true
       env:

--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -42,4 +42,5 @@ jobs:
           token-dev3: ${{ secrets.TRUNK_DEV3_ORG_API_TOKEN }}
           token-dev4: ${{ secrets.TRUNK_DEV4_ORG_API_TOKEN }}
           cli-version: ${{ inputs.cli-version }}
-          junit-paths: bazel-testlogs/**/test.xml
+          junit-paths: ""
+          bazel-bep-path: build_events.json


### PR DESCRIPTION
This includes 2 changes
1. Add bazel configuration to generate a [BEP file](https://bazel.build/remote/bep)
2. Tell the analytics-uploader action to upload that BEP file

[Verified upload successful](https://github.com/trunk-io/flake-factory/actions/runs/12754252381/job/35547672168?pr=12961)